### PR TITLE
Added extra sanitation to remove '\r' from type identifiers 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "wg-getters-and-setters",
-    "version": "1.0.5",
+    "version": "1.1.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,7 @@ function createGetterAndSetter(textProperties: string) {
         let rows = properties[p].split(" ").map(x => x.replace('\r\n', ''));
         for (let row of rows) {
             if (row.trim() !== '') {
-                words.push(row);
+                words.push(row.replace('\r',''));
             }
         }
         let type, attribute, Attribute = "";


### PR DESCRIPTION
Added extra sanitation to remove '\r' from type identifiers which caused opening carrybrace on getter methods and closing braket on setter method signature to fall on next line hence causing miss format.